### PR TITLE
[Admin] Entourages#index : improvements for moderation

### DIFF
--- a/app/controllers/admin/join_requests_controller.rb
+++ b/app/controllers/admin/join_requests_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class JoinRequestsController < Admin::BaseController
+    def create
+      @entourage = Entourage.find params[:joinable_id]
+
+      builder = JoinRequestsServices::AdminAcceptedJoinRequestBuilder.new(joinable: @entourage, user: current_user)
+      if builder.create
+          flash[:success] = "Vous avez bien rejoint l'entourage."
+          redirect_to admin_entourage_path(@entourage)
+      else
+          flash[:notice] = "Vous n'avez pas pu rejoindre l'entourage."
+          redirect_to admin_entourage_path(@entourage)
+      end
+    end
+  end
+end

--- a/app/models/entourage.rb
+++ b/app/models/entourage.rb
@@ -42,6 +42,12 @@ class Entourage < ActiveRecord::Base
     false
   end
 
+  def approximated_location
+   location ||= Geocoder.search([latitude, longitude]).first
+   return '' unless location
+   "#{location.city}, #{location.postal_code}"
+  end
+
   protected
 
   def check_moderation

--- a/app/services/join_requests_services/admin_accepted_join_request_builder.rb
+++ b/app/services/join_requests_services/admin_accepted_join_request_builder.rb
@@ -8,7 +8,7 @@ module JoinRequestsServices
     def create
       return false unless @user.admin?
 
-      join_request = JoinRequest.create(joinable: @joinable, user: @user,  status: JoinRequest::ACCEPTED_STATUS)
+      join_request = JoinRequest.new(joinable: @joinable, user: @user,  status: JoinRequest::ACCEPTED_STATUS)
 
       if join_request.save
 

--- a/app/services/join_requests_services/admin_accepted_join_request_builder.rb
+++ b/app/services/join_requests_services/admin_accepted_join_request_builder.rb
@@ -1,0 +1,28 @@
+module JoinRequestsServices
+  class AdminAcceptedJoinRequestBuilder
+    def initialize(joinable:, user:)
+      @joinable = joinable
+      @user     = user
+    end
+
+    def create
+      return false unless @user.admin?
+
+      join_request = JoinRequest.create(joinable: @joinable, user: @user,  status: JoinRequest::ACCEPTED_STATUS)
+
+      if join_request.save
+
+        title   = "Invitation accepté"
+        content = "Un membre de l'équipe Entourage a rejoint votre action pour vous aider."
+        meta    = { joinable_id: join_request.joinable_id,
+                    joinable_type: join_request.joinable_type,
+                    type: "JOIN_REQUEST_ACCEPTED",
+                    user_id: @user.id }
+
+        PushNotificationService.new.send_notification(@user.first_name, title, content, [@joinable.user], meta)
+      end
+
+      join_request
+    end
+  end
+end

--- a/app/views/admin/entourages/index.html.erb
+++ b/app/views/admin/entourages/index.html.erb
@@ -11,6 +11,7 @@
     <th style="width:15%">Titre</th>
     <th>Créé le</th>
     <th style="width:20%">Description</th>
+    <th>Location</th>
     <th>Auteur</th>
     <th>Organisation</th>
     <th>Email</th>
@@ -26,6 +27,7 @@
         <td><%= link_to_entourage_with_infos(entourage) %></td>
         <td><%= entourage.created_at.strftime('%d/%m/%Y') %></td>
         <td><%= entourage_description_excerpt(entourage.description) %></td>
+        <td><%= entourage.approximated_location %></td>
         <td><%= link_to("#{entourage.user.full_name} (##{entourage.user.id})", admin_user_path(entourage.user)) %></td>
         <td><%= entourage.user.organization.try(:name) %></td>
         <td><%= entourage.user.email %></td>

--- a/app/views/admin/entourages/show.html.erb
+++ b/app/views/admin/entourages/show.html.erb
@@ -12,6 +12,9 @@
       </div>
       <div class='col-sm-4 '>
         <div class='pull-right'>
+          <%- unless @entourage.members.include?(current_user)%>
+            <%= link_to "Rejoindre", admin_join_requests_path(joinable_id: @entourage), class: "btn btn-info", method: :post %>
+          <% end %>
           <%= link_to "Modifier", edit_admin_entourage_path(@entourage), class: "btn btn-success" %>
         </div>
       </div>

--- a/app/views/admin/entourages/show/_details.html.erb
+++ b/app/views/admin/entourages/show/_details.html.erb
@@ -5,6 +5,8 @@
 
   <div class='col-sm-4 '>
     <div class='pull-right'>
+      <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span>
+      <%= @entourage.approximated_location %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
       resources :entourage_invitations, only: [:index]
       resources :entourages, only: [:index, :show, :edit, :update]
       resources :marketing_referers, only: [:index, :edit, :update, :new, :create]
+      resources :join_requests, only: [:create]
 
       get 'public_user_search' => "users_search#public_user_search"
       get 'public_user_autocomplete' => "users_search#public_user_autocomplete"
@@ -66,6 +67,7 @@ Rails.application.routes.draw do
     resources :entourage_invitations, only: [:index]
     resources :entourages, only: [:index, :show, :edit, :update]
     resources :marketing_referers, only: [:index, :edit, :update, :new, :create]
+    resources :join_requests, only: [:create]
 
     get 'public_user_search' => "users_search#public_user_search"
     get 'public_user_autocomplete' => "users_search#public_user_autocomplete"

--- a/spec/services/join_requests_services/admin_accepted_join_request_builder_spec.rb
+++ b/spec/services/join_requests_services/admin_accepted_join_request_builder_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe JoinRequestsServices::AdminAcceptedJoinRequestBuilder do
+
+  context "should create an accepted join request without invitation" do
+    let(:organization)   { FactoryGirl.create(:organization) }
+    let(:entourage)      { FactoryGirl.create(:entourage) }
+    let(:admin_user)     { FactoryGirl.create(:user, admin: true, organization: organization) }
+    let(:non_admin_user) { FactoryGirl.create(:user, admin: false, organization: organization) }
+
+    it "should be valid" do
+      JoinRequestsServices::AdminAcceptedJoinRequestBuilder.new(joinable: entourage, user: admin_user).create
+
+      expect(Entourage.last.members.include?(User.last)).to be true
+    end
+
+    it "should not be valid" do
+      JoinRequestsServices::AdminAcceptedJoinRequestBuilder.new(joinable: entourage, user: non_admin_user).create
+
+      expect(Entourage.last.members.include?(User.last)).to be false
+    end
+
+  end
+end


### PR DESCRIPTION
Added approximated location. 
Added ability for an admin to join an entourage without being invited or accepted.

https://trello.com/c/Ezk7cvcn/750-feature-moderation-des-entourages-dans-admin-entourage-social