### PR TITLE
improve the perfs of user_applications#update

### DIFF
--- a/app/controllers/api/v1/user_applications_controller.rb
+++ b/app/controllers/api/v1/user_applications_controller.rb
@@ -4,7 +4,7 @@ module Api
       #curl -X PUT -H 'API_KEY:2b8259ac4aad2cfd0b46be77' -d '{ "application": {"device_family": "ANDROID", "device_os": "android 6.0.1", "push_token": "fSxmlgKhWuY:APA91bEgeYtJsRRwZQAJxaeoelG42N9NuDH8Im3Mor8F1_TplGhRnXUrI6MhZRppXOwyuHKjWVWTn1Cu0zCdO_U8DjR2VQFE0rDx4d4PLQ123Tixw-tfxLi2gB6QraZBCPE1Q9F2lijy", "version": "1.2.608" }}' -H "Content-Type: application/json" "http://localhost:3000/api/v1/applications.json?token=0cb4507e970462ca0b11320131e96610"
       def update
         ActiveRecord::Base.transaction do
-          UserApplication.where(push_token: user_application_params["push_token"]).destroy_all
+          UserApplication.where(push_token: user_application_params["push_token"]).delete_all
           if user_application_params["push_token"] == "0" || user_application_params["push_token"] == ""
             @current_user.user_applications.where(device_os: user_application_params["device_os"], version: user_application_params["version"]).destroy_all
             head :no_content

--- a/db/migrate/20170907131932_add_index_on_push_token_to_user_applications.rb
+++ b/db/migrate/20170907131932_add_index_on_push_token_to_user_applications.rb
@@ -1,0 +1,5 @@
+class AddIndexOnPushTokenToUserApplications < ActiveRecord::Migration
+  def change
+    add_index :user_applications, :push_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170617201542) do
+ActiveRecord::Schema.define(version: 20170907131932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -414,6 +414,7 @@ ActiveRecord::Schema.define(version: 20170617201542) do
     t.string   "device_family"
   end
 
+  add_index "user_applications", ["push_token"], name: "index_user_applications_on_push_token", using: :btree
   add_index "user_applications", ["user_id", "device_os", "version"], name: "index_user_applications_on_user_id_and_device_os_and_version", unique: true, using: :btree
 
   create_table "user_newsfeeds", force: :cascade do |t|


### PR DESCRIPTION
add an index on `user_applications.token`
replace an unnecessary `destroy_all` by a less costly `delete_all`

Trello: https://trello.com/c/MkIhmSOH/890

`destroy_all` instancie tous les objets pour pouvoir appeler les callbacks `before_destroy` et `dependant: :delete|:destroy` sur les associations.

Cela pouvait conduire à n+1 requêtes si plusieurs `UserApplication` existaient pour le `push_token` concerné (exemple ici avec 5):

```
> UserApplication.where(push_token: t).destroy_all
  UserApplication Load (2.5ms)  SELECT "user_applications".* FROM "user_applications" WHERE "user_applications"."push_token" = $1  [["push_token", "b3294be800a510051ecf01f54ecc7a9fe58caef7a5eec3ad7342facec13c765f"]]
   (0.2ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "user_applications" WHERE "user_applications"."id" = $1  [["id", 79709]]
   (2.1ms)  COMMIT
   (0.1ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "user_applications" WHERE "user_applications"."id" = $1  [["id", 51568]]
   (2.1ms)  COMMIT
   (0.2ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "user_applications" WHERE "user_applications"."id" = $1  [["id", 32282]]
   (2.3ms)  COMMIT
   (0.1ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "user_applications" WHERE "user_applications"."id" = $1  [["id", 15459]]
   (2.3ms)  COMMIT
   (0.1ms)  BEGIN
  SQL (0.2ms)  DELETE FROM "user_applications" WHERE "user_applications"."id" = $1  [["id", 8952]]
   (2.9ms)  COMMIT
```

La destruction de chaque objet était également effectuée dans une nouvelle transaction, ce qui augmentait le coût de chaque opération.

Il n'y a actuellement aucun callback lors de la destruction d'une `UserApplication`. On peut donc utiliser un simple `delete_all` (`DELETE FROM "user_applications" WHERE "user_applications"."push_token" = $1`).

Enfin, l'absence d'index sur `user_applications.token` conduisait à un scan séquentiel de la table lors du `destroy_all` et pour la validation `uniqueness_of :push_token` effectuée lors de la création et des mises à jour d'une `UserApplication`.