### PR TITLE
Optimize the /pois endpoint response time

### DIFF
--- a/app/services/api/application_key.rb
+++ b/app/services/api/application_key.rb
@@ -49,5 +49,23 @@ module Api
         "fbe5ec205f074b7533c2dbd6" => {version: "3.6.0", device: "Android", device_family: UserApplication::ANDROID},
       }
     end
+
+    class Version
+      include Comparable
+
+      def initialize version
+        @version_array = parse(version)
+      end
+
+      def <=> other
+        @version_array <=> parse(other)
+      end
+
+      private
+      def parse value
+        raise ArgumentError, "version must be a String" unless value.is_a?(String)
+        value.split('.')
+      end
+    end
   end
 end

--- a/app/services/poi_services/poi_optimized_serializer.rb
+++ b/app/services/poi_services/poi_optimized_serializer.rb
@@ -1,0 +1,112 @@
+module PoiServices
+  class PoiOptimizedSerializer
+    CACHE_KEY_PREFIX = "json_cache/#{Poi.model_name.cache_key}".freeze
+    CACHE_KEY_FORMAT = "#{CACHE_KEY_PREFIX}/%d-%d".freeze
+
+    def initialize(pois_scope, box_size:, &serializer)
+      @pois = pois_scope
+      @box_size = box_size.to_f
+      @serializer = serializer
+    end
+
+    def serialize
+      pois_metadata = @pois.pluck(with_clustering(:id, :updated_at))
+
+      return [] if pois_metadata.empty?
+
+      cache_keys_by_id = {}
+      pois_metadata.each do |id, timestamp|
+        cache_keys_by_id[id] = CACHE_KEY_FORMAT % [id, timestamp.utc.to_s(:nsec)]
+      end
+
+      cached_values = $redis.mget(*cache_keys_by_id.values)
+
+      ids = pois_metadata.map(&:first)
+      pois_by_id = {}
+      ids_to_fetch_from_database = []
+
+      ids.zip(cached_values).each do |id, cached_value|
+        if cached_value != nil
+          pois_by_id[id] = cached_value
+        else
+          ids_to_fetch_from_database.push(id)
+        end
+      end
+
+      if ids_to_fetch_from_database.any?
+        pois_from_database = Poi.where(id: ids_to_fetch_from_database)
+        cache_writes = []
+
+        @serializer.call(pois_from_database).each do |poi|
+          json = poi.to_json
+          pois_by_id[poi[:id]] = json
+          cache_writes.push(cache_keys_by_id[poi[:id]], json)
+        end
+
+        $redis.mset(*cache_writes)
+      end
+
+      ids.map { |id| SerializedJSON.new(pois_by_id[id]) }
+    end
+
+    private
+    # Divides the area in a grid of squares and keep only one POI per square
+    def with_clustering *projections
+      if @box_size >= 10
+        grid_size = @box_size / 15
+      elsif @box_size >= 5
+        grid_size = @box_size / 30
+      else
+        # no clustering
+        return projections.join(", ")
+      end
+
+      %(
+        distinct on (
+          ST_SnapToGrid(
+            ST_Transform(
+              ST_SetSRID(
+                ST_MakePoint(longitude, latitude),
+                4326),
+              3785),
+            #{grid_size * 1000})
+        )
+        #{projections.join(", ")}
+      )
+    end
+
+    # wraps a JSON fragment to prevent the encoder to re-serialize it
+    class SerializedJSON < BasicObject
+      def initialize(json)
+        @json = json
+      end
+
+      def as_json *args
+        self
+      end
+
+      def to_json *args
+        @json
+      end
+    end
+
+    # patches the JSON encoder to handle pre-serialized fragments
+    module EncoderMixin
+      private
+      def jsonify(value)
+        case value
+        when SerializedJSON
+          value
+        else
+          super
+        end
+      end
+    end
+
+    ActiveSupport.json_encoder.prepend(EncoderMixin)
+
+    def self.clear_cache
+      $redis.del($redis.keys("#{CACHE_KEY_PREFIX}/*"))
+    end
+  end
+end

--- a/spec/controllers/api/v1/pois_controller_spec.rb
+++ b/spec/controllers/api/v1/pois_controller_spec.rb
@@ -70,7 +70,7 @@ describe Api::V1::PoisController, :type => :controller do
         end
 
         context 'with distance' do
-          before { get :index, token: user.token, latitude: 10.0, longitude: 10.0, distance: 20.0, format: :json }
+          before { get :index, token: user.token, latitude: 10.0, longitude: 10.0, distance: 40.0, format: :json }
           it { expect(response.status).to eq(200) }
           it { expect(assigns[:pois]).to eq [poi2, poi3, poi4] }
         end


### PR DESCRIPTION
### reduce the "radius" (it's actually a square)
The distance returned by the iOS app is the that of the entire screen but we were treating it on the backend as if it was a radius (half the size). This caused us to return POIs for an area 4x larger than what was displayed.

The way the Android app was calculating the distance was broken, it has been updated (https://github.com/ReseauEntourage/entourage-android/commit/1fdbfeeab216411a09b942c9cb8df5e1fc1beffc) to match the implementation of the iOS app.

### cache the serialized JSON for each POI in Redis
We now do a first SQL request to fetch the POIs cache keys from the database. We then query the full data and do the serialization only for the POIs that are not in the cache. This reduces the serialization time, the SQL response size, and the memory consumption.

### server side clustering at low zoom levels
We now filter out some POIs that are close to each other when the display area is larger that 5⨉5 km, then more aggressively above 10⨉10 km.
The goal was to reduce the payload size when displaying the entire city of Paris or the entire country of France.
The logic is that the map is divided in squares (30⨉30 at high zoom, 15⨉15 at low zoom) and that only one POI is returned for each square.