### PR TITLE
Vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ db/sensitive-words/*.txt
 
 # Vagrant
 .vagrant
+ubuntu-xenial*

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ use-node
 
 # sensitive words category files
 db/sensitive-words/*.txt
+
+# Vagrant
+.vagrant

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 [![Build Status](https://semaphoreci.com/api/v1/projects/e06001fd-34da-4414-9789-e09e3f28c67a/623094/badge.svg)](https://semaphoreci.com/vdaubry/entourage-ror)
 [![Coverage Status](https://coveralls.io/repos/ReseauEntourage/entourage-ror/badge.svg?branch=master&service=github)](https://coveralls.io/github/ReseauEntourage/entourage-ror?branch=master)
 
+# Vagrant
+
+See the [relevant documentation](docs/Vagrant.md) for installing with Vagrant.
+
 # Prerequisites
 
 Ruby 2.3.1

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,41 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provision :shell, privileged: false, path: "scripts/vagrant_setup.sh"
+
+  # Make this VM reachable on the host network as well, so that other
+  # VM's running other browsers can access our dev server.
+  config.vm.network :private_network, ip: "192.168.10.200"
+
+  # Make it so that network access from the vagrant guest is able to
+  # use SSH private keys that are present on the host without copying
+  # them into the VM.
+  config.ssh.forward_agent = true
+
+  config.vm.provider :virtualbox do |v|
+    # This setting gives the VM 1024MB of RAM instead of the default 384.
+    v.memory = [ENV["ENTOURAGE_VM_MEM"].to_i, 1024].max
+
+    # Determine the available cores in host system or default to 2.
+    v.cpus =
+      case RUBY_PLATFORM
+      when /linux/
+        `nproc`.to_i
+      when /darwin/
+        `sysctl -n hw.ncpu`.to_i
+      else
+        2
+      end
+
+    # Enable I/O APIC to allow for multiple virtual CPUs
+    v.customize ["modifyvm", :id, "--ioapic", "on"]
+
+    # This setting makes it so that network access from inside the vagrant guest
+    # is able to resolve DNS using the hosts VPN connection.
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  config.vm.network :forwarded_port, guest: 3000, host: 4000
+
+  config.vm.synced_folder ".", "/home/vagrant/entourage-ror", id: "vagrant-root"
+end

--- a/docs/Vagrant.md
+++ b/docs/Vagrant.md
@@ -12,7 +12,7 @@
 
 ### Local Hostnames Setup
 
-Some features of the Entourage backend app are only accessible through an `admin.*` subdomain. One way of setting this up is to edit your [hosts file] to have the `admin.entourage.dev` hostname resolve to your computer.
+Some features of the Entourage backend app are only accessible through an `admin.*` subdomain. One way of setting this up is to edit your [hosts file] to have the `admin.entourage.local` hostname resolve to your computer.
 
 ```bash
 $ sudo vim /etc/hostname
@@ -21,7 +21,7 @@ $ sudo vim /etc/hostname
 Then, tap on the `i` key and use the arrow keys on your keyboard to navigate the text area. Modify your hosts file so that it resembles the following:
 
 ```
-127.0.0.1 localhost entourage.dev admin.entourage.dev
+127.0.0.1 localhost entourage.local admin.entourage.local
 ```
 
 To save and exit, tap the `Esc` key, on your keyboard, followed by these keystrokes: `:`, `w`, `q`, and, finally, `Enter`.
@@ -60,7 +60,7 @@ You can start a rails instance using the following command from the `~/entourage
 $ bundle exec rails server -b 0.0.0.0
 ```
 
-In a few seconds, rails will start serving pages. To access them, open a web browser to http://entourage.dev:4000 - if it all worked you should see the Entourage app! Congratulations, you are ready to start working!
+In a few seconds, rails will start serving pages. To access them, open a web browser to http://entourage.local:4000 - if it all worked you should see the Entourage app! Congratulations, you are ready to start working!
 
 You can now edit files on your local file system, using your favorite text editor or IDE. When you reload your web browser, it should have the latest changes.
 
@@ -84,8 +84,8 @@ FactoryGirl.create :public_user, admin: true, phone: "+33600000001", sms_code: "
 This creates an admin account with the phone number `+33600000001` and the SMS code `123123`.
 Then type `Ctrl`+`D` to leave this console.
 
-Ensure that you have started the Rails server, and open http://admin.entourage.dev:4000/sessions/new in your browser.
-Log in with the credentials, and head to http://admin.entourage.dev:4000/admin to access the admin interface.
+Ensure that you have started the Rails server, and open http://admin.entourage.local:4000/sessions/new in your browser.
+Log in with the credentials, and head to http://admin.entourage.local:4000/admin to access the admin interface.
 
 
 ### Shutting down the VM

--- a/docs/Vagrant.md
+++ b/docs/Vagrant.md
@@ -1,0 +1,97 @@
+# Vagrant Install Guide
+
+### Getting Started
+
+1. Install Git
+2. Install VirtualBox: https://www.virtualbox.org/wiki/Downloads
+3. Install Vagrant: https://www.vagrantup.com/downloads.html
+4. Open a terminal
+5. Clone the project: `git clone https://github.com/ReseauEntourage/entourage-ror.git`
+6. Enter the project directory: `cd entourage-ror`
+
+
+### Local Hostnames Setup
+
+Some features of the Entourage backend app are only accessible through an `admin.*` subdomain. One way of setting this up is to edit your [hosts file] to have the `admin.entourage.dev` hostname resolve to your computer.
+
+```bash
+$ sudo vim /etc/hostname
+```
+
+Then, tap on the `i` key and use the arrow keys on your keyboard to navigate the text area. Modify your hosts file so that it resembles the following:
+
+```
+127.0.0.1 localhost entourage.dev admin.entourage.dev
+```
+
+To save and exit, tap the `Esc` key, on your keyboard, followed by these keystrokes: `:`, `w`, `q`, and, finally, `Enter`.
+
+[hosts file]: https://en.wikipedia.org/wiki/Hosts_(file)
+
+
+### Using Vagrant
+
+When you're ready to start working, boot the VM:
+```bash
+$ vagrant up
+```
+
+The first time that you run it, this command will take a few minutes to complete, because it has a lot of set up to do.
+
+Once the virtual machine has booted up, you can shell into it by typing:
+
+```bash
+$ vagrant ssh
+```
+
+Now you're in a virtual machine, almost ready to start developing.
+The Entourage code is found in the `entourage-ror` directory:
+
+```bash
+$ cd entourage-ror
+```
+
+
+### Starting Rails
+
+You can start a rails instance using the following command from the `~/entourage-ror` directory:
+
+```bash
+$ bundle exec rails server -b 0.0.0.0
+```
+
+In a few seconds, rails will start serving pages. To access them, open a web browser to http://entourage.dev:4000 - if it all worked you should see the Entourage app! Congratulations, you are ready to start working!
+
+You can now edit files on your local file system, using your favorite text editor or IDE. When you reload your web browser, it should have the latest changes.
+
+
+### Creating an Admin User
+
+You'll want an admin account to be able to do anything fun on your new Entourage environment. Enter your Vagrant image by using `vagrant ssh` then
+run the following command to open a console that will let you interact with the Rails application from the command line:
+
+```bash
+$ bundle exec rails console
+```
+
+In this console, execute the following Ruby code:
+```ruby
+require 'factory_girl'
+require_relative 'spec/factories/users.rb'
+FactoryGirl.create :public_user, admin: true, phone: "+33600000001", sms_code: "123123"
+```
+
+This creates an admin account with the phone number `+33600000001` and the SMS code `123123`.
+Then type `Ctrl`+`D` to leave this console.
+
+Ensure that you have started the Rails server, and open http://admin.entourage.dev:4000/sessions/new in your browser.
+Log in with the credentials, and head to http://admin.entourage.dev:4000/admin to access the admin interface.
+
+
+### Shutting down the VM
+
+When you're done working on the Entourage app, you can log out of the virtual machine, then shut down Vagrant with:
+
+``` bash
+$ vagrant halt
+```

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -1,29 +1,65 @@
 #!/usr/bin/env bash
-set -o pipefail
 
-cd ~/entourage-ror
+set -eo pipefail
 
-# Setup Ubuntu locale
+# install dependencies
 cat <<EOF | sudo tee /etc/default/locale
 LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8
 EOF
 
-# Install most dependencies from Ubuntu packages
 sudo apt-get -yqq update
 sudo apt-get -yqq install \
   build-essential \
   nodejs \
   postgresql postgresql-contrib postgis libpq-dev \
-  redis-server
+  redis-server libsqlite3-dev
 
-# Install Ruby via RVM
-curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-curl -sSL https://get.rvm.io | bash -s stable
-source ~/.rvm/scripts/rvm
-$rvm_recommended_ruby --quiet-curl --default
-echo 'gem: --no-document' >> ~/.gemrc
-gem install bundler
+
+###
+# Install ruby
+###
+
+mkdir ruby
+cd ruby
+
+# add postmodern PGP key
+wget https://raw.github.com/postmodern/postmodern.github.io/master/postmodern.asc
+gpg --import postmodern.asc
+
+# install ruby-install
+wget -q https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-0.6.1.tar.gz.asc
+wget -qO ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
+gpg --verify ruby-install-0.6.1.tar.gz.asc ruby-install-0.6.1.tar.gz
+tar -xzvf ruby-install-0.6.1.tar.gz
+cd ruby-install-0.6.1/
+sudo make install
+
+# install pinned ruby version
+ruby-install ruby 2.3.1
+
+# install chruby
+wget -q https://raw.github.com/postmodern/chruby/master/pkg/chruby-0.3.9.tar.gz.asc
+wget -qO chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
+gpg --verify chruby-0.3.9.tar.gz.asc chruby-0.3.9.tar.gz
+tar -xzvf chruby-0.3.9.tar.gz
+cd chruby-0.3.9/
+sudo make install
+echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.bashrc
+echo 'chruby ruby' >> ~/.bashrc
+source /usr/local/share/chruby/chruby.sh
+
+# activate our ruby version
+chruby ruby
+
+# cleanup
+cd ..
+rm -rf ruby
+
+###
+# /Install ruby
+###
+
 
 # Configure PostgreSQL authentication
 sudo -u postgres createuser --superuser --createdb entourage || true
@@ -32,5 +68,9 @@ sudo sed -i 's|^\(host .*\) md5$|\1 trust|' /etc/postgresql/*/main/pg_hba.conf
 sudo service postgresql reload
 
 # Setup app
+cd /home/vagrant/entourage-ror
+echo 'gem: --no-document' >> ~/.gemrc
+gem install bundler
 bundle install --without production
-bundle exec rake db:setup db:test:prepare
+bundle exec rake db:drop db:create db:migrate
+bundle exec rake RAILS_ENV=test db:drop db:create db:migrate

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+RUBY_VERSION="2.3.1"
+RUBY_INSTALL_VERSION="0.6.1"
+CHRUBY_VERSION="0.3.9"
+
+
 # install dependencies
 cat <<EOF | sudo tee /etc/default/locale
 LC_ALL=en_US.UTF-8
@@ -28,22 +33,22 @@ wget https://raw.github.com/postmodern/postmodern.github.io/master/postmodern.as
 gpg --import postmodern.asc
 
 # install ruby-install
-wget -q https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-0.6.1.tar.gz.asc
-wget -qO ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
-gpg --verify ruby-install-0.6.1.tar.gz.asc ruby-install-0.6.1.tar.gz
-tar -xzvf ruby-install-0.6.1.tar.gz
-cd ruby-install-0.6.1/
+wget -q "https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-$RUBY_INSTALL_VERSION.tar.gz.asc"
+wget -qO "ruby-install-$RUBY_INSTALL_VERSION.tar.gz" "https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"
+gpg --verify "ruby-install-$RUBY_INSTALL_VERSION.tar.gz.asc" "ruby-install-$RUBY_INSTALL_VERSION.tar.gz"
+tar -xzvf "ruby-install-$RUBY_INSTALL_VERSION.tar.gz"
+cd "ruby-install-$RUBY_INSTALL_VERSION/"
 sudo make install
 
 # install pinned ruby version
-ruby-install ruby 2.3.1
+ruby-install ruby $RUBY_VERSION
 
 # install chruby
-wget -q https://raw.github.com/postmodern/chruby/master/pkg/chruby-0.3.9.tar.gz.asc
-wget -qO chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
-gpg --verify chruby-0.3.9.tar.gz.asc chruby-0.3.9.tar.gz
-tar -xzvf chruby-0.3.9.tar.gz
-cd chruby-0.3.9/
+wget -q "https://raw.github.com/postmodern/chruby/master/pkg/chruby-$CHRUBY_VERSION.tar.gz.asc"
+wget -qO "chruby-$CHRUBY_VERSION.tar.gz" "https://github.com/postmodern/chruby/archive/v$CHRUBY_VERSION.tar.gz"
+gpg --verify "chruby-$CHRUBY_VERSION.tar.gz.asc" "chruby-$CHRUBY_VERSION.tar.gz"
+tar -xzvf "chruby-$CHRUBY_VERSION.tar.gz"
+cd "chruby-$CHRUBY_VERSION/"
 sudo make install
 echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.bashrc
 echo 'chruby ruby' >> ~/.bashrc

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+cd ~/entourage-ror
+
+# Setup Ubuntu locale
+cat <<EOF | sudo tee /etc/default/locale
+LC_ALL=en_US.UTF-8
+LANG=en_US.UTF-8
+EOF
+
+# Install most dependencies from Ubuntu packages
+sudo apt-get -yqq update
+sudo apt-get -yqq install \
+  build-essential \
+  nodejs \
+  postgresql postgresql-contrib postgis libpq-dev \
+  redis-server
+
+# Install Ruby via RVM
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+curl -sSL https://get.rvm.io | bash -s stable
+source ~/.rvm/scripts/rvm
+$rvm_recommended_ruby --quiet-curl --default
+echo 'gem: --no-document' >> ~/.gemrc
+gem install bundler
+
+# Configure PostgreSQL authentication
+sudo -u postgres createuser --superuser --createdb entourage || true
+sudo sed -i 's|^\(local .*\) peer$|\1 trust|' /etc/postgresql/*/main/pg_hba.conf
+sudo sed -i 's|^\(host .*\) md5$|\1 trust|' /etc/postgresql/*/main/pg_hba.conf
+sudo service postgresql reload
+
+# Setup app
+bundle install --without production
+bundle exec rake db:setup db:test:prepare


### PR DESCRIPTION
Hello Entourage !

J'ai repris la PR #171 de @gregclermont pour un setup à partir de zéro à travers Vagrant. 

Pour référence: le Vagrantfile est inspiré du projet Discourse, le script de setup utilise [chruby](https://github.com/postmodern/chruby) pour installer la version de ruby indiquée dans le gemfile et les urls de dev sont en *.entourage.local (l'extension *.dev force le https sur chrome et firefox).