### PR TITLE
fix: size of pushtoken for Android can be either 152 or 174

### DIFF
--- a/app/controllers/api/v1/user_applications_controller.rb
+++ b/app/controllers/api/v1/user_applications_controller.rb
@@ -16,6 +16,7 @@ module Api
         device_family =
           case user_application_params[:push_token].length
           when 152 then UserApplication::ANDROID
+          when 174 then UserApplication::ANDROID
           when  64 then UserApplication::IOS
           else api_request.key_infos.try(:[], :device_family)
           end


### PR DESCRIPTION
La taille des push token Android peut aussi aussi de 174 caractères