### PR TITLE
Feature/denorm daily activities (#263)

### DIFF
--- a/db/migrate/20221028053601_add_creation_group_type_index_to_entourages.rb
+++ b/db/migrate/20221028053601_add_creation_group_type_index_to_entourages.rb
@@ -1,0 +1,13 @@
+class AddCreationGroupTypeIndexToEntourages < ActiveRecord::Migration[5.2]
+  def up
+    add_index :entourages, :created_at
+    add_index :entourages, [:community,:group_type]
+    add_index :join_requests, [:requested_at, :created_at]
+  end
+
+  def down
+    remove_index :entourages, :created_at
+    remove_index :entourages, [:community,:group_type]
+    remove_index :join_requests, [:requested_at, :created_at]
+  end
+end

--- a/db/migrate/20221028103700_create_denorm_daily_engagements.rb
+++ b/db/migrate/20221028103700_create_denorm_daily_engagements.rb
@@ -1,0 +1,63 @@
+class CreateDenormDailyEngagements < ActiveRecord::Migration[5.2]
+  def up
+    create_table :denorm_daily_engagements do |t|
+      t.date :date, null: false
+      t.integer :user_id, null: false
+      t.string :postal_code
+
+      t.index [:date, :user_id, :postal_code], unique: true, name: 'unicity_denorm_daily_engagements_on_date_user_id_postal_code'
+    end
+  end
+
+  def down
+    remove_index :denorm_daily_engagements, [:date, :user_id, :postal_code]
+
+    drop_table :denorm_daily_engagements
+  end
+end
+
+#init this table with this request:
+# insert into denorm_daily_engagements 
+# select 
+#       date(timezone('Europe/Paris', created_at at time zone 'UTC')),
+#       user_id,
+#       coalesce(case when country = 'FR' then postal_code end, 'unkown')
+#     from entourages 
+#     where entourages.community = 'entourage' and entourages.group_type in ('action', 'outing') /*and created_at >= ('2022-01-01')*/
+# on conflict ("date", user_id, postal_code) do nothing;
+
+# insert into denorm_daily_engagements 
+# select 
+#       date(timezone('Europe/Paris', chat_messages.created_at at time zone 'UTC')),
+#       chat_messages.user_id,
+#       coalesce(case when country = 'FR' then postal_code end, 'unkown') 
+#     from chat_messages join entourages 
+#       on messageable_type = 'Entourage' and messageable_id = entourages.id 
+#       and entourages.community = 'entourage' and entourages.group_type in ('action', 'outing')
+#     where message_type = 'text'  /*and chat_messages.created_at >= '2022-01-01'*/
+# on conflict ("date", user_id, postal_code) do nothing;
+
+# insert into denorm_daily_engagements 
+# select  
+#       date(timezone('Europe/Paris', chat_messages.created_at at time zone 'UTC')),
+#       chat_messages.user_id,
+#       coalesce(case when sender_addresses.country = 'FR' then sender_addresses.postal_code end, 'unkown')
+#     from chat_messages join entourages 
+#       on messageable_type = 'Entourage' and messageable_id = entourages.id 
+#       and entourages.community = 'entourage' and entourages.group_type = 'conversation'
+#     join users sender on sender.id = chat_messages.user_id
+#     left join addresses sender_addresses on sender_addresses.id = address_id
+#     where message_type = 'text' /*and chat_messages.created_at >= '2022-01-01'*/
+# on conflict ("date", user_id, postal_code) do nothing;
+
+# insert into denorm_daily_engagements 
+# select  
+#       date(timezone('Europe/Paris', coalesce(requested_at, join_requests.created_at) at time zone 'UTC')),
+#       join_requests.user_id,
+#       coalesce(case when country = 'FR' then postal_code end, 'unkown')
+#     from join_requests join entourages 
+#       on joinable_type = 'Entourage' and joinable_id = entourages.id 
+#       and entourages.community = 'entourage' and entourages.group_type in ('action', 'outing')
+#     where (group_type = 'outing' or (message is not null and trim(message, ' \n') != ''))
+#     /*and coalesce(requested_at, join_requests.created_at) = '2022-01-01'*/
+# on conflict ("date", user_id, postal_code) do nothing;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,13 @@ ActiveRecord::Schema.define(version: 2022_10_27_135700) do
     t.integer "organization_id"
   end
 
+  create_table "denorm_daily_engagements", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "user_id", null: false
+    t.string "postal_code"
+    t.index ["date", "user_id", "postal_code"], name: "unicity_denorm_daily_engagements_on_date_user_id_postal_code", unique: true
+  end
+
   create_table "digest_emails", id: :serial, force: :cascade do |t|
     t.datetime "deliver_at", null: false
     t.jsonb "data", default: {}, null: false

--- a/spec/services/home_services/outing_spec.rb
+++ b/spec/services/home_services/outing_spec.rb
@@ -15,7 +15,7 @@ describe HomeServices::Outing do
     it 'should find outings within user travel_distance' do
       user.update_attribute(:travel_distance, 8)
 
-      expect(subject.find_all).to eq([outing, second, online])
+      expect(subject.find_all).to match_array([outing, second, online])
     end
 
     it 'should not find outings outside user travel_distance' do


### PR DESCRIPTION
* featue: add denorm table for user engagement
* Rename 20221028053601_add_index_to_engagments.rb to 20221028053601_add_creation_group_type_index_to_entourages.rb
* fix index name length
* use match_array rather than eq to compare arrays

Co-authored-by: Nicolas Ech Chafaï <75681929+nicolas-entourage@users.noreply.github.com>