### PR TITLE
Handle duplicate campaign member error in Salesforce synchronization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.2.3'
+ruby '3.2.0'
 
 gem 'rails', '~> 7.1.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.2.0'
+ruby '3.2.3'
 
 gem 'rails', '~> 7.1.0'
 

--- a/app/services/salesforce_services/connect.rb
+++ b/app/services/salesforce_services/connect.rb
@@ -64,15 +64,21 @@ module SalesforceServices
     end
 
     def upsert_from_fields fields
-      # create when no external id is set
-      return client.create!(interface.table_name, **fields) unless instance.try(interface.external_id_key).present?
+      begin
+        # create when no external id is set
+        return client.create!(interface.table_name, **fields) unless instance.try(interface.external_id_key).present?
 
-      client.upsert!(
-        interface.table_name,
-        interface.external_id_value,
-        interface.external_id_value => instance.try(interface.external_id_key),
-        **fields
-      )
+        client.upsert!(
+          interface.table_name,
+          interface.external_id_value,
+          interface.external_id_value => instance.try(interface.external_id_key),
+          **fields
+        )
+      rescue Restforce::ErrorCode::DuplicateValue
+        return unless id = find_id
+
+        client.update(interface.table_name, Id: id, **fields)
+      end
     end
 
     def destroy

--- a/app/services/salesforce_services/connect.rb
+++ b/app/services/salesforce_services/connect.rb
@@ -77,6 +77,10 @@ module SalesforceServices
       rescue Restforce::ErrorCode::DuplicateValue
         return unless id = find_id
 
+        if (ext_id_value = interface.try(:external_id_value)) && (ext_id_key = instance.try(interface.external_id_key))
+          fields[ext_id_value] = ext_id_key
+        end
+
         client.update(interface.table_name, Id: id, **fields)
       end
     end

--- a/app/services/salesforce_services/join_request.rb
+++ b/app/services/salesforce_services/join_request.rb
@@ -45,14 +45,31 @@ module SalesforceServices
       [:status, :participate_at]
     end
 
+    def find_id
+      return id if id = super
+
+      return unless contact_id = find_contact_id
+      return unless campaign_id = find_campaign_id
+
+      client.query("select Id from CampaignMember where ContactId = '#{contact_id}' and CampaignId = '#{campaign_id}'").first&.Id
+    end
+
     private
+
+    def find_contact_id
+      @contact_id ||= SalesforceServices::Contact.new(user).find_id
+    end
+
+    def find_campaign_id
+      @campaign_id ||= SalesforceServices::Outing.new(outing).find_id
+    end
 
     def find_or_initialize_contact_id
       contact_id || contact_id!
     end
 
     def contact_id
-      @contact_id ||= SalesforceServices::Contact.new(user).find_id
+      find_contact_id
     end
 
     def contact_id!
@@ -60,11 +77,11 @@ module SalesforceServices
     end
 
     def find_or_initialize_campaign_id
-      campaign_id || campaign_id!
+      find_campaign_id || campaign_id!
     end
 
     def campaign_id
-      @campaign_id ||= SalesforceServices::Outing.new(outing).find_id
+      find_campaign_id
     end
 
     def campaign_id!

--- a/app/services/salesforce_services/sf_entreprise_join_request.rb
+++ b/app/services/salesforce_services/sf_entreprise_join_request.rb
@@ -16,6 +16,10 @@ module SalesforceServices
       })
     end
 
+    def find_id
+      client.query("select Id from CampaignMember where ContactId = '#{@sf_contact_id}' and CampaignId = '#{@sf_campaign_id}'").first&.Id
+    end
+
     def interface
       @interface ||= OpenStruct.new(
         table_name: "CampaignMember",

--- a/spec/services/salesforce_services/join_request_spec.rb
+++ b/spec/services/salesforce_services/join_request_spec.rb
@@ -48,7 +48,7 @@ describe SalesforceServices::JoinRequest do
 
     it "calls upsert! on client" do
       expect_any_instance_of(Restforce::Client).to receive(:upsert!).with(
-        "CampaignMember", "JoinRequestId__c", hash_including(JoinRequestId__c: join_request.id)
+        "CampaignMember", "JoinRequestId__c", hash_including("JoinRequestId__c" => join_request.id)
       )
       subject.upsert
     end
@@ -60,7 +60,7 @@ describe SalesforceServices::JoinRequest do
 
       it "falls back to update after finding id" do
         expect_any_instance_of(Restforce::Client).to receive(:query).with(
-          "select Id from CampaignMember where JoinRequestId__c = '#{join_request.id}'"
+          "select Id from CampaignMember where JoinRequestId__c = #{join_request.id}"
         ).and_return([])
 
         expect_any_instance_of(Restforce::Client).to receive(:query).with(
@@ -68,7 +68,7 @@ describe SalesforceServices::JoinRequest do
         ).and_return([OpenStruct.new(Id: 'sf_campaign_member_id')])
 
         expect_any_instance_of(Restforce::Client).to receive(:update).with(
-          "CampaignMember", hash_including(Id: 'sf_campaign_member_id')
+          "CampaignMember", hash_including(Id: 'sf_campaign_member_id', "JoinRequestId__c" => join_request.id)
         )
 
         subject.upsert

--- a/spec/services/salesforce_services/join_request_spec.rb
+++ b/spec/services/salesforce_services/join_request_spec.rb
@@ -35,4 +35,44 @@ describe SalesforceServices::JoinRequest do
       it { expect(subject).to be(false) }
     end
   end
+
+  describe "upsert" do
+    let(:outing) { create(:outing) }
+    let(:join_request) { create(:join_request, joinable: outing) }
+    let(:subject) { SalesforceServices::JoinRequest.new(join_request) }
+
+    before {
+      SalesforceServices::Contact.any_instance.stub(:find_id) { 'sf_contact_id' }
+      SalesforceServices::Outing.any_instance.stub(:find_id) { 'sf_campaign_id' }
+    }
+
+    it "calls upsert! on client" do
+      expect_any_instance_of(Restforce::Client).to receive(:upsert!).with(
+        "CampaignMember", "JoinRequestId__c", hash_including(JoinRequestId__c: join_request.id)
+      )
+      subject.upsert
+    end
+
+    context "when duplicate error occurs" do
+      before {
+        expect_any_instance_of(Restforce::Client).to receive(:upsert!).and_raise(Restforce::ErrorCode::DuplicateValue.new("Déjà membre de campagne.", "DUPLICATE_VALUE"))
+      }
+
+      it "falls back to update after finding id" do
+        expect_any_instance_of(Restforce::Client).to receive(:query).with(
+          "select Id from CampaignMember where JoinRequestId__c = '#{join_request.id}'"
+        ).and_return([])
+
+        expect_any_instance_of(Restforce::Client).to receive(:query).with(
+          "select Id from CampaignMember where ContactId = 'sf_contact_id' and CampaignId = 'sf_campaign_id'"
+        ).and_return([OpenStruct.new(Id: 'sf_campaign_member_id')])
+
+        expect_any_instance_of(Restforce::Client).to receive(:update).with(
+          "CampaignMember", hash_including(Id: 'sf_campaign_member_id')
+        )
+
+        subject.upsert
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses the `Restforce::ErrorCode::DuplicateValue` error during Salesforce synchronization. It implements a fallback mechanism to find and update existing `CampaignMember` records when a creation attempt fails due to unique constraint violations on `ContactId` and `CampaignId`.

---
*PR created automatically by Jules for task [15553426762292685714](https://jules.google.com/task/15553426762292685714) started by @nicolas-entourage*