### PR TITLE
Add unsubscribe button in backoffice for events and neighborhoods

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -30,7 +30,7 @@ module Admin
 
     def ensure_moderator!
       unless current_user.roles.include?(:moderator)
-        render text: "Cette action nécessite d'être modérateur", status: :unauthorized
+        render plain: "Cette action nécessite d'être modérateur", status: :unauthorized
       end
     end
   end

--- a/app/controllers/admin/join_requests_controller.rb
+++ b/app/controllers/admin/join_requests_controller.rb
@@ -25,13 +25,12 @@ module Admin
         flash[:error] = "La personne n'a pas pu être désinscrite : #{@join_request.errors.full_messages.to_sentence}"
       end
 
-      redirect_to case @joinable
-      when Neighborhood
-        show_members_admin_neighborhood_path(@joinable)
-      when Entourage
-        show_members_admin_entourage_path(@joinable)
+      if @joinable.is_a?(Neighborhood)
+        redirect_to show_members_admin_neighborhood_path(@joinable)
+      elsif @joinable.is_a?(Entourage)
+        redirect_to show_members_admin_entourage_path(@joinable)
       else
-        [:admin, @joinable]
+        redirect_to [:admin, @joinable]
       end
     end
   end

--- a/app/controllers/admin/join_requests_controller.rb
+++ b/app/controllers/admin/join_requests_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class JoinRequestsController < Admin::BaseController
-    before_action :ensure_moderator!, only: [:create]
+    before_action :ensure_moderator!, only: [:create, :destroy]
 
     def create
       @entourage = Entourage.find params[:joinable_id]
@@ -12,6 +12,26 @@ module Admin
       else
         flash[:notice] = "Vous n'avez pas pu rejoindre l'entourage."
         redirect_to admin_entourage_path(@entourage)
+      end
+    end
+
+    def destroy
+      @join_request = JoinRequest.find(params[:id])
+      @joinable = @join_request.joinable
+
+      if @join_request.update(status: :cancelled)
+        flash[:success] = "La personne a bien été désinscrite."
+      else
+        flash[:error] = "La personne n'a pas pu être désinscrite : #{@join_request.errors.full_messages.to_sentence}"
+      end
+
+      redirect_to case @joinable
+      when Neighborhood
+        show_members_admin_neighborhood_path(@joinable)
+      when Entourage
+        show_members_admin_entourage_path(@joinable)
+      else
+        [:admin, @joinable]
       end
     end
   end

--- a/app/controllers/organization_admin/base_controller.rb
+++ b/app/controllers/organization_admin/base_controller.rb
@@ -86,13 +86,13 @@ module OrganizationAdmin
 
     def ensure_org_member!
       unless current_user.partner_id.present?
-        render text: "Cette action nécessite d'être membre d'une organisation", status: :unauthorized
+        render plain: "Cette action nécessite d'être membre d'une organisation", status: :unauthorized
       end
     end
 
     def ensure_org_admin!
       unless current_user.partner_admin?
-        render text: "Cette action nécessite d'être administrateur de l'organisation", status: :unauthorized
+        render plain: "Cette action nécessite d'être administrateur de l'organisation", status: :unauthorized
       end
     end
   end

--- a/app/controllers/organization_admin/descriptions_controller.rb
+++ b/app/controllers/organization_admin/descriptions_controller.rb
@@ -42,7 +42,7 @@ module OrganizationAdmin
 
     def ensure_can_edit_description!
       unless OrganizationAdmin::Permissions.can_edit_description?(current_user)
-        render text: "Vous n'avez pas la permission de modifier la description", status: :unauthorized
+        render plain: "Vous n'avez pas la permission de modifier la description", status: :unauthorized
       end
     end
 

--- a/app/controllers/organization_admin/invitations_controller.rb
+++ b/app/controllers/organization_admin/invitations_controller.rb
@@ -113,7 +113,7 @@ module OrganizationAdmin
 
     def ensure_can_invite_member!
       unless OrganizationAdmin::Permissions.can_invite_member?(current_user)
-        render text: "Vous n'avez pas la permission d'inviter un membre", status: :unauthorized
+        render plain: "Vous n'avez pas la permission d'inviter un membre", status: :unauthorized
       end
     end
 

--- a/app/controllers/organization_admin/members_controller.rb
+++ b/app/controllers/organization_admin/members_controller.rb
@@ -55,13 +55,13 @@ module OrganizationAdmin
 
     def ensure_can_edit_member!
       unless OrganizationAdmin::Permissions.can_edit_member?(current_user)
-        render text: "Vous n'avez pas la permission de modifier un membre", status: :unauthorized
+        render plain: "Vous n'avez pas la permission de modifier un membre", status: :unauthorized
       end
     end
 
     def ensure_can_remove_member!
       unless OrganizationAdmin::Permissions.can_remove_member?(current_user)
-        render text: "Vous n'avez pas la permission de retirer un membre", status: :unauthorized
+        render plain: "Vous n'avez pas la permission de retirer un membre", status: :unauthorized
       end
     end
 

--- a/app/views/admin/entourages/show/_show_members.html.erb
+++ b/app/views/admin/entourages/show/_show_members.html.erb
@@ -21,6 +21,7 @@
       <th>Profil</th>
       <th>Email</th>
       <th>Téléphone</th>
+      <th>Actions</th>
     </tr>
   </thead>
 
@@ -60,6 +61,11 @@
 
         <td><%= member.email %></td>
         <td><%= member.phone %></td>
+        <td>
+          <% if member.id != @entourage.user_id %>
+            <%= link_to "Désinscrire", admin_join_request_path(request), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir désinscrire ce membre ?" }, class: "btn btn-danger btn-xs" %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
 

--- a/app/views/admin/neighborhoods/show_members.html.erb
+++ b/app/views/admin/neighborhoods/show_members.html.erb
@@ -40,6 +40,7 @@
       <th>Téléphone</th>
       <th>Statut</th>
       <th>Profil</th>
+      <th>Actions</th>
       <% @members.each do |member| %>
         <tr>
           <td><%= member.id %></td>
@@ -59,6 +60,14 @@
               <span class="custom-badge info" title="Profil renseigné par l'utilisateur">
                 <%= t "community.entourage.goals_compact.#{member.goal}" %>
               </span>
+            <% end %>
+          </td>
+          <td>
+            <% if member.id != @neighborhood.user_id %>
+              <% join_request = JoinRequest.where(joinable: @neighborhood, user: member, status: :accepted).first %>
+              <% if join_request.present? %>
+                <%= link_to "Désinscrire", admin_join_request_path(join_request), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir désinscrire ce membre ?" }, class: "btn btn-danger btn-xs" %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :join_requests, only: [:create]
+      resources :join_requests, only: [:create, :destroy]
 
       resources :messages, only: [:index, :destroy]
 

--- a/spec/controllers/admin/join_requests_controller_spec.rb
+++ b/spec/controllers/admin/join_requests_controller_spec.rb
@@ -21,7 +21,10 @@ describe Admin::JoinRequestsController do
       before { user.update(roles: []) }
 
       it { expect { request }.not_to change { join_request.reload.status } }
-      it { expect(request.status).to eq('401') }
+      it {
+        request
+        expect(response.status).to eq(401)
+      }
     end
 
     context 'for an outing' do

--- a/spec/controllers/admin/join_requests_controller_spec.rb
+++ b/spec/controllers/admin/join_requests_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+include AuthHelper
+
+describe Admin::JoinRequestsController do
+  let!(:user) { admin_basic_login }
+  let(:neighborhood) { create(:neighborhood) }
+  let(:member) { create(:public_user) }
+  let!(:join_request) { create(:join_request, joinable: neighborhood, user: member, status: :accepted, role: :member) }
+
+  describe 'DELETE #destroy' do
+    let(:request) { delete :destroy, params: { id: join_request.id } }
+
+    context 'as a moderator' do
+      before { user.update(roles: [:moderator]) }
+
+      it { expect { request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
+      it { expect(request).to redirect_to(show_members_admin_neighborhood_path(neighborhood)) }
+    end
+
+    context 'as a non-moderator' do
+      before { user.update(roles: []) }
+
+      it { expect { request }.not_to change { join_request.reload.status } }
+      it { expect(request.status).to eq('401') }
+    end
+
+    context 'for an outing' do
+      let(:outing) { create(:outing) }
+      let!(:join_request) { create(:join_request, joinable: outing, user: member, status: :accepted, role: :participant) }
+
+      before { user.update(roles: [:moderator]) }
+
+      it { expect { request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
+      it { expect(request).to redirect_to(show_members_admin_entourage_path(outing)) }
+    end
+  end
+end

--- a/spec/controllers/admin/join_requests_controller_spec.rb
+++ b/spec/controllers/admin/join_requests_controller_spec.rb
@@ -8,21 +8,24 @@ describe Admin::JoinRequestsController do
   let!(:join_request) { create(:join_request, joinable: neighborhood, user: member, status: :accepted, role: :member) }
 
   describe 'DELETE #destroy' do
-    let(:request) { delete :destroy, params: { id: join_request.id } }
+    let(:do_request) { delete :destroy, params: { id: join_request.id } }
 
     context 'as a moderator' do
       before { user.update(roles: [:moderator]) }
 
-      it { expect { request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
-      it { expect(request).to redirect_to(show_members_admin_neighborhood_path(neighborhood)) }
+      it { expect { do_request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
+      it {
+        do_request
+        expect(response).to redirect_to(show_members_admin_neighborhood_path(neighborhood))
+      }
     end
 
     context 'as a non-moderator' do
       before { user.update(roles: []) }
 
-      it { expect { request }.not_to change { join_request.reload.status } }
+      it { expect { do_request }.not_to change { join_request.reload.status } }
       it {
-        request
+        do_request
         expect(response.status).to eq(401)
       }
     end
@@ -33,8 +36,11 @@ describe Admin::JoinRequestsController do
 
       before { user.update(roles: [:moderator]) }
 
-      it { expect { request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
-      it { expect(request).to redirect_to(show_members_admin_entourage_path(outing)) }
+      it { expect { do_request }.to change { join_request.reload.status }.from('accepted').to('cancelled') }
+      it {
+        do_request
+        expect(response).to redirect_to(show_members_admin_entourage_path(outing))
+      }
     end
   end
 end


### PR DESCRIPTION
This change allows administrators to unsubscribe users from events (outings) or neighborhood groups directly from the backoffice members list. A confirmation dialog is prompted before the action is executed.

---
*PR created automatically by Jules for task [2664299193469973888](https://jules.google.com/task/2664299193469973888) started by @nicolas-entourage*