### PR TITLE
Fix Heroku Deployment CI Failure

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,12 +66,8 @@ jobs:
       - name: Setup API Procfile
         run: cp Procfile.api-prod Procfile
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
       - name: Deploy API to Heroku
-        uses: akhileshns/heroku-deploy@v3.8.9
+        uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: entourage-back
@@ -91,12 +87,8 @@ jobs:
       - name: Setup API Procfile
         run: cp Procfile.backoffice-prod Procfile
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
       - name: Deploy API to Heroku
-        uses: akhileshns/heroku-deploy@v3.8.9
+        uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: local-backoffice-prod

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -66,12 +66,8 @@ jobs:
       - name: Setup API Procfile
         run: cp Procfile.api-preprod Procfile
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
       - name: Deploy API to Heroku
-        uses: akhileshns/heroku-deploy@v3.8.9
+        uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: entourage-back-preprod
@@ -91,12 +87,8 @@ jobs:
       - name: Setup Backoffice Procfile
         run: cp Procfile.backoffice-preprod Procfile
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
       - name: Deploy Backoffice to Heroku
-        uses: akhileshns/heroku-deploy@v3.8.9
+        uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: local-backoffice-preprod


### PR DESCRIPTION
I fixed the failing GitHub Actions CI/CD pipeline by updating the `akhileshns/heroku-deploy` action to version `v3.14.15` and removing the manual Heroku CLI installation step in both `staging.yml` and `master.yml` workflows. This addresses the `TypeError: process.stdin.setRawMode is not a function` error caused by newer Heroku CLI versions attempting interactive authentication in a non-interactive CI environment.

---
*PR created automatically by Jules for task [7664171020884364417](https://jules.google.com/task/7664171020884364417) started by @nicolas-entourage*