### PR TITLE
Optimize national neighborhoods endpoint payload

### DIFF
--- a/app/controllers/api/v1/neighborhoods_controller.rb
+++ b/app/controllers/api/v1/neighborhoods_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       def index
         render json: NeighborhoodServices::Finder.new(current_user, index_params).find_all
-          .includes(:translation, :image_resize_actions, :user)
+          .includes(:translation, :image_resize_actions, :user, :join_requests)
           .page(page)
           .per(per), root: :neighborhoods, each_serializer: ::V1::Neighborhoods::NotMemberListSerializer, scope: { user: current_user }
       end
@@ -19,9 +19,9 @@ module Api
         })
 
         render json: NeighborhoodServices::Finder.new(current_user, national_params).find_all
-          .includes(:translation, :image_resize_actions, :user)
+          .includes(:translation, :image_resize_actions, :user, :join_requests)
           .page(page)
-          .per(per), root: :neighborhoods, each_serializer: ::V1::NeighborhoodHomeSerializer, scope: { user: current_user }
+          .per(per), root: :neighborhoods, each_serializer: ::V1::Neighborhoods::NationalSerializer, scope: { user: current_user }
       end
 
       def default

--- a/app/serializers/v1/neighborhoods/national_serializer.rb
+++ b/app/serializers/v1/neighborhoods/national_serializer.rb
@@ -1,0 +1,130 @@
+module V1
+  module Neighborhoods
+    class NationalSerializer < ActiveModel::Serializer
+      attributes :id,
+        :uuid_v2,
+        :name,
+        :name_translations,
+        :description,
+        :description_translations,
+        :welcome_message,
+        :member,
+        :members,
+        :members_count,
+        :unread_posts_count,
+        :image_url,
+        :interests,
+        :ethics,
+        :past_outings_count,
+        :future_outings_count,
+        :has_ongoing_outing,
+        :address,
+        :posts,
+        :public,
+        :national,
+        :user,
+        :outings,
+        :future_outings,
+        :ongoing_outings
+
+      def name
+        I18nSerializer.new(object, :name, lang).translation
+      end
+
+      def name_translations
+        I18nSerializer.new(object, :name, lang).translations
+      end
+
+      def description
+        ""
+      end
+
+      def description_translations
+        { translation: "", original: "", from_lang: "fr", to_lang: "fr" }
+      end
+
+      def welcome_message
+        nil
+      end
+
+      def member
+        return false unless scope && scope[:user]
+
+        if object.association(:join_requests).loaded?
+          object.join_requests.any? { |jr| jr.user_id == scope[:user].id && jr.status == 'accepted' }
+        else
+          JoinRequest.where(joinable: object, user: scope[:user], status: :accepted).exists?
+        end
+      end
+
+      def members
+        []
+      end
+
+      def unread_posts_count
+        0
+      end
+
+      def image_url
+        object.image_url_with_size :high
+      end
+
+      def interests
+        []
+      end
+
+      def ethics
+        []
+      end
+
+      def past_outings_count
+        0
+      end
+
+      def future_outings_count
+        0
+      end
+
+      def has_ongoing_outing
+        false
+      end
+
+      def address
+        {
+          latitude: object.latitude,
+          longitude: object.longitude,
+          street_address: object.street_address,
+          display_address: [object.place_name, object.postal_code].compact.uniq.join(', ')
+        }
+      end
+
+      def posts
+        []
+      end
+
+      def user
+        {}
+      end
+
+      def outings
+        []
+      end
+
+      def future_outings
+        []
+      end
+
+      def ongoing_outings
+        []
+      end
+
+      private
+
+      def lang
+        return unless scope && scope[:user] && scope[:user].lang
+
+        scope[:user].lang
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit optimizes the `/api/v1/neighborhoods/national` endpoint. 

Previously, it returned large arrays of posts, events, and a fake 99 member array list, which bloated the JSON payload sizes significantly.

This creates a dedicated `NationalSerializer` containing the necessary fields for the UI (`id`, `name`, `members_count`, `image_url`, and `member`).
Other relations (like `outings`, `future_outings`, `posts`, and large descriptive strings) are scrubbed and mocked out to empty values `[]` or `""` or `nil` as to ensure retro-compatibility with older apps while keeping the payload extremely light.

It also introduces eager loading for `join_requests` in the controller and checks the `loaded?` association in the serializer to determine if the user is a `member` without introducing N+1 queries.

---
*PR created automatically by Jules for task [10548092277197727637](https://jules.google.com/task/10548092277197727637) started by @clemPerrousset*